### PR TITLE
Add ES5 compiled dist

### DIFF
--- a/dist/word-search-solver.js
+++ b/dist/word-search-solver.js
@@ -1,0 +1,153 @@
+'use strict';
+
+module.exports = function(letterMatrix, wordList) {
+  var result = [];
+  for(var i = 0; i < wordList.length; i++) {
+    var location = FindWordInMatrix(wordList[i], letterMatrix);
+    var wordResult = {
+      word: wordList[i],
+      found: false
+    }
+
+    if( location[0][0] + location[0][1] + location[1][0] + location[1][1] > 0 ) {
+      wordResult.found = true;
+      wordResult.firstLetter = location[0];
+      wordResult.lastLetter = location[1];
+    }
+    result.push(wordResult);
+  }
+  return result;
+};
+
+function FindWordInMatrix(word, matrix) {
+  // Start by looking for the starting letter
+  var startLetter = word[0];
+  var wl = word.length -1;
+  var height = matrix.length;
+  // console.log('Searching word', word);
+  // console.log('Searching width', width);
+  // console.log('Searching matrix', matrix);
+  // console.log('startLetter', startLetter);
+
+  for(var x = 0; x < matrix.length; x++) {
+    for(var y = 0; y < matrix.length; y++) {
+      if(matrix[y][x] === startLetter) {
+        var width = matrix[y].length;
+        // console.log(`Found on [${y},${x}]`);
+        var possibleDirections = ['l','lu','u','ru','r','rd','d','ld'];
+        // exclude possible directions
+        for(var d = 0; d < possibleDirections.length; d++) {
+          var direction = possibleDirections[d];
+          switch(direction) {
+            case 'l':
+              if (x - wl >= 0) {
+                var match = true;
+                for(var c = 1; c <= wl; c++) {
+                  if(matrix[y][x -c] !== word[c]) {
+                    match = false;
+                  }
+                }
+                if(match) { return [[y,x], [y, x - wl]]; }
+              } else {
+                // console.log('Does not fit to left');
+              }
+              break;
+            case 'lu':
+             if (x - wl >= 0 && y - wl >= 0) {
+                var match$1 = true;
+                for(var c$1 = 1; c$1 <= wl; c$1++) {
+                  if(matrix[y - c$1][x - c$1] !== word[c$1]) {
+                    match$1 = false;
+                  }
+                }
+                if(match$1) { return [[y,x], [y - wl, x - wl]]; }
+              } else {
+                // console.log('Does not fit to left up');
+              }
+              break;
+            case 'u':
+              if (y - wl >= 0) {
+                var match$2 = true;
+                for(var c$2 = 1; c$2 <= wl; c$2++) {
+                  if(matrix[y - c$2][x] !== word[c$2]) {
+                    match$2 = false;
+                  }
+                }
+                if(match$2) { return [[y,x], [y - wl, x]]; }
+              } else {
+                // console.log('Does not fit to up');
+              }
+              break;
+            case 'ru':
+              if (x + wl < width && y - wl >= 0) {
+                var match$3 = true;
+                for(var c$3 = 1; c$3 <= wl; c$3++) {
+                  if(matrix[y - c$3][x + c$3] !== word[c$3]) {
+                    match$3 = false;
+                  }
+                }
+                if(match$3) { return [[y,x], [y - wl, x + wl]]; }
+              } else {
+                // console.log('Does not fit to right up');
+              }
+              break;
+            case 'r':
+              if (x + wl < width) {
+                var match$4 = true;
+                for(var c$4 = 1; c$4 <= wl; c$4++) {
+                  if(matrix[y][x + c$4] !== word[c$4]) {
+                    match$4 = false;
+                  }
+                }
+                if(match$4) { return [[y,x], [y, x + wl]]; }
+              } else {
+                // console.log('Does not fit to right');
+              }
+              break;
+            case 'rd':
+              if (x + wl < width && y + wl < height) {
+                var match$5 = true;
+                for(var c$5 = 1; c$5 <= wl; c$5++) {
+                  if(matrix[y + c$5][x + c$5] !== word[c$5]) {
+                    match$5 = false;
+                  }
+                }
+                if(match$5) { return [[y,x], [y + wl, x + wl]]; }
+              } else {
+                // console.log('Does not fit to right down');
+              }
+              break;
+            case 'd':
+              if (y + wl < height) {
+                var match$6 = true;
+                for(var c$6 = 1; c$6 <= wl; c$6++) {
+                  if(matrix[y + c$6][x] !== word[c$6]) {
+                    match$6 = false;
+                  }
+                }
+                if(match$6) { return [[y,x], [y + wl, x]]; }
+              } else {
+                // console.log('Does not fit to down');
+              }
+              break;
+            case 'ld':
+            if (x - wl >= 0 && y + wl < height) {
+                var match$7 = true;
+                for(var c$7 = 1; c$7 <= wl; c$7++) {
+                  if(matrix[y + c$7][x - c$7] !== word[c$7]) {
+                    match$7 = false;
+                  }
+                }
+                if(match$7) { return [[y,x], [y + wl, x - wl]]; }
+              } else {
+                // console.log('Does not fit to left down');
+              }
+              break;
+          }
+        }
+      }
+    }
+  }
+
+  return [[0, 0], [0, 0]];
+}

--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = require('./src/word-search-solver.js');
+module.exports = require('./dist/word-search-solver.js');

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Utility to solve word search puzzles",
   "main": "index.js",
   "scripts": {
+    "build": "buble src/word-search-solver.js -o dist/word-search-solver.js",
     "test": "mocha test/test.js",
     "cover": "istanbul cover node_modules/mocha/bin/_mocha -- -R spec test/*"
   },
@@ -23,6 +24,7 @@
   },
   "homepage": "https://github.com/JHotterbeekx/word-search-solver#readme",
   "devDependencies": {
+    "buble": "^0.19.3",
     "chai": "^4.1.0",
     "coveralls": "^3.0.0",
     "istanbul": "^0.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,6 +10,22 @@ abbrev@1.0.x:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.0.9.tgz#91b4792588a7738c25f35dd6f63752a2f8776135"
 
+acorn-dynamic-import@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz#901ceee4c7faaef7e07ad2a47e890675da50a278"
+  dependencies:
+    acorn "^5.0.0"
+
+acorn-jsx@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-4.1.1.tgz#e8e41e48ea2fe0c896740610ab6a4ffd8add225e"
+  dependencies:
+    acorn "^5.0.3"
+
+acorn@^5.0.0, acorn@^5.0.3, acorn@^5.4.1:
+  version "5.5.3"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.5.3.tgz#f473dd47e0277a08e28e9bec5aeeb04751f0b8c9"
+
 ajv@^5.1.0:
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
@@ -30,6 +46,12 @@ align-text@^0.1.1, align-text@^0.1.3:
 amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
+
+ansi-styles@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
+  dependencies:
+    color-convert "^1.9.0"
 
 argparse@^1.0.7:
   version "1.0.9"
@@ -98,6 +120,19 @@ browser-stdout@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.0.tgz#f351d32969d32fa5d7a5567154263d928ae3bd1f"
 
+buble@^0.19.3:
+  version "0.19.3"
+  resolved "https://registry.yarnpkg.com/buble/-/buble-0.19.3.tgz#01e9412062cff1da6f20342b6ecd72e7bf699d02"
+  dependencies:
+    acorn "^5.4.1"
+    acorn-dynamic-import "^3.0.0"
+    acorn-jsx "^4.1.1"
+    chalk "^2.3.1"
+    magic-string "^0.22.4"
+    minimist "^1.2.0"
+    os-homedir "^1.0.1"
+    vlq "^1.0.0"
+
 camelcase@^1.0.2:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-1.2.1.tgz#9bb5304d2e0b56698b2c758b08a3eaa9daa58a39"
@@ -124,6 +159,14 @@ chai@^4.1.0:
     pathval "^1.0.0"
     type-detect "^4.0.0"
 
+chalk@^2.3.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.2.tgz#250dc96b07491bfd601e648d66ddf5f60c7a5c65"
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
+
 check-error@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
@@ -139,6 +182,16 @@ cliui@^2.1.0:
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
+
+color-convert@^1.9.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.1.tgz#c1261107aeb2f294ebffec9ed9ecad529a6097ed"
+  dependencies:
+    color-name "^1.1.1"
+
+color-name@^1.1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
 
 combined-stream@^1.0.5, combined-stream@~1.0.5:
   version "1.0.5"
@@ -214,7 +267,7 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
 
-escape-string-regexp@1.0.5:
+escape-string-regexp@1.0.5, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
@@ -349,6 +402,10 @@ has-flag@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
 
+has-flag@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+
 hawk@~6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/hawk/-/hawk-6.0.2.tgz#af4d914eb065f9b5ce4d9d11c1cb2126eecc3038"
@@ -481,6 +538,12 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
+magic-string@^0.22.4:
+  version "0.22.4"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.22.4.tgz#31039b4e40366395618c1d6cf8193c53917475ff"
+  dependencies:
+    vlq "^0.2.1"
+
 mime-db@~1.30.0:
   version "1.30.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.30.0.tgz#74c643da2dd9d6a45399963465b26d5ca7d71f01"
@@ -567,6 +630,10 @@ optionator@^0.8.1:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
     wordwrap "~1.0.0"
+
+os-homedir@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
 
 path-is-absolute@^1.0.0:
   version "1.0.1"
@@ -693,6 +760,12 @@ supports-color@^3.1.0:
   dependencies:
     has-flag "^1.0.0"
 
+supports-color@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.3.0.tgz#5b24ac15db80fa927cf5227a4a33fd3c4c7676c0"
+  dependencies:
+    has-flag "^3.0.0"
+
 tough-cookie@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.3.tgz#0b618a5565b6dea90bf3425d04d55edc475a7561"
@@ -743,6 +816,14 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
+
+vlq@^0.2.1:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/vlq/-/vlq-0.2.3.tgz#8f3e4328cf63b1540c0d67e1b2778386f8975b26"
+
+vlq@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/vlq/-/vlq-1.0.0.tgz#8101be90843422954c2b13eb27f2f3122bdcc806"
 
 which@^1.1.1:
   version "1.3.0"


### PR DESCRIPTION
This adds an ES5-compiled version in `dist/` and switches `index.js` to require it instead. Allows this package to be imported as is by bundlers like Webpack. Forked for my own usage but figured I'd share in case you were interested.

Related: https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md#npm-run-build-fails-to-minify